### PR TITLE
Move typescript declarations to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
 	"main": "index.js",
 	"license": "MIT",
 	"dependencies": {
-		"@types/bcrypt": "^3.0.0",
-		"@types/express": "^4.17.8",
-		"@types/node": "^14.14.6",
 		"apollo-server": "^2.19.0",
 		"axios": "^0.21.1",
 		"bcrypt": "^5.0.0",
@@ -20,6 +17,9 @@
 		"typescript": "^4.0.3"
 	},
 	"devDependencies": {
+		"@types/bcrypt": "^3.0.0",
+		"@types/express": "^4.17.8",
+		"@types/node": "^14.14.6",
 		"@types/react": "^16.9.49",
 		"@typescript-eslint/eslint-plugin": "^4.1.0",
 		"@typescript-eslint/parser": "^4.1.0",


### PR DESCRIPTION
The repository dependencies `@types/bcrypt`, `@types/express`, and `@types/node` should be `devDependencies`, as they are not necessary during runtime, only during TypeScript compilation. This matches the other type declarations, which are already `devDependencies`.